### PR TITLE
[FIX] Fixed chat size

### DIFF
--- a/packages/rocketchat-livechat/assets/rocket-livechat.js
+++ b/packages/rocketchat-livechat/assets/rocket-livechat.js
@@ -486,7 +486,7 @@
 	var scrollPosition;
 
 	var widgetWidth = '320px';
-	var widgetHeightOpened = '350px';
+	var widgetHeightOpened = '380px';
 	var widgetHeightClosed = '30px';
 
 	var validCallbacks = [


### PR DESCRIPTION
The bottom part was cut

@RocketChat/core 

The iframe is 380px in size, when using the chat on some webpages the bottom part is cut.
Fixes a problem with the Wordpress plugin.